### PR TITLE
Use injected usage supplier in RuntimeTaskImpl.

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -19,7 +19,7 @@ import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.runtime.Job;
 import io.mantisrx.runtime.loader.RuntimeTask;
 import io.mantisrx.runtime.loader.SinkSubscriptionStateHandler;
-import io.mantisrx.runtime.loader.cgroups.CgroupsMetricsCollector;
+import io.mantisrx.runtime.loader.config.MetricsCollector;
 import io.mantisrx.runtime.loader.config.WorkerConfiguration;
 import io.mantisrx.runtime.loader.config.WorkerConfigurationUtils;
 import io.mantisrx.runtime.loader.config.WorkerConfigurationWritable;
@@ -99,8 +99,9 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
             this.wrappedExecuteStageRequest =
                 new WrappedExecuteStageRequest(PublishSubject.create(), executeStageRequest);
 
-            log.info("Picking Cgroups metrics collector.");
-            configWritable.setMetricsCollector(CgroupsMetricsCollector.valueOf(System.getProperties()));
+            MetricsCollector metricsCollector = config.getUsageSupplier();
+            log.info("Picking " + metricsCollector.getClass().getName() + ".");
+            configWritable.setMetricsCollector(metricsCollector);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Summary
Use injected usage supplier in RuntimeTaskImpl.

### Context
Currently `CgroupsMetricsCollector` is hard-coded in `RuntimeTaskImpl.java`, so if it is overridden using the `
mantis.taskexecutor.metrics.collector` field in the Mantis agent properties, that isn't respected. This change uses the dynamically loaded implementation of `MetricsCollector`.

### Checklist
- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
